### PR TITLE
Benutze "current_timestamp()" statt "CURRENT_TIMESTAMP"

### DIFF
--- a/code/zuordnen.php
+++ b/code/zuordnen.php
@@ -4664,7 +4664,7 @@ function update_database( $version ) {
       logger( 'starting update_database: from version 17' );
 
       doSql( "ALTER TABLE `produkte` ADD COLUMN `dauerbrenner` tinyint(1) not null default 0 " );
-      doSql( "ALTER TABLE `sessions` ADD COLUMN `session_timestamp` timestamp not null default CURRENT_TIMESTAMP " );
+      doSql( "ALTER TABLE `sessions` ADD COLUMN `session_timestamp` timestamp not null default current_timestamp() " );
       doSql( "ALTER TABLE `bestellvorschlaege` ADD COLUMN `vorschlag_gruppen_id` int(11) not null default 0 " );
 
       sql_update( 'leitvariable', array( 'name' => 'database_version' ), array( 'value' => 18 ) );

--- a/setup.php
+++ b/setup.php
@@ -45,7 +45,7 @@ $problems = false;
 
 function escape_val( $val ) {
   switch( $val ) {
-    case 'CURRENT_TIMESTAMP';
+    case 'current_timestamp()';
       return $val;
     default:
       return "'$val'";

--- a/structure.php
+++ b/structure.php
@@ -246,7 +246,7 @@ $tables = array(
     , 'zeitpunkt' => array(
         'type' =>  "timestamp"
       , 'null' => 'NO'
-      , 'default' => 'CURRENT_TIMESTAMP'
+      , 'default' => 'current_timestamp()'
       , 'extra' => ''
       )
     )
@@ -680,7 +680,7 @@ $tables = array(
     , 'eingabe_zeit' => array(
         'type' =>  "timestamp"
       , 'null' => 'NO'
-      , 'default' => 'CURRENT_TIMESTAMP'
+      , 'default' => 'current_timestamp()'
       , 'extra' => ''
       )
     , 'summe' => array(
@@ -1072,7 +1072,7 @@ $tables = array(
     , 'time_stamp' => array(
         'type' =>  "timestamp"
       , 'null' => 'NO'
-      , 'default' => 'CURRENT_TIMESTAMP'
+      , 'default' => 'current_timestamp()'
       , 'extra' => ''
       )
     , 'notiz' => array(
@@ -1318,7 +1318,7 @@ $tables = array(
     , 'session_timestamp' => array(
         'type' =>  "timestamp"
       , 'null' => 'NO'
-      , 'default' => 'CURRENT_TIMESTAMP'
+      , 'default' => 'current_timestamp()'
       , 'extra' => ''
       )
     , 'muteReconfirmation_timestamp' => array(


### PR DESCRIPTION
Damit gibt setup.php keine falschen Fehler mehr aus.